### PR TITLE
Preserve position while not animating

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,7 +1,11 @@
 .frt-fixed-content-wrapper {
-  	position: fixed;
-  	left: 0;
-  	right: 0;
-  	bottom: 0;
-  	top: 0;
+  position: static;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
+}
+
+.fri-fixed-content-wrapper.velocity-animating {
+  position: fixed;
 }


### PR DESCRIPTION
This applies `position: fixed` only while animating. This way, content wrapped will behave as normal while not transitioning (in terms of scrolling etc.).
